### PR TITLE
Changing environment setup to point to online and VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The most popular of PDDL used today are PDDL2.1, which is an extension to PDDL f
 
 ## Environment Setup
 
-You can use your own text editor, but I would recommend using [Sublime Text](https://www.sublimetext.com/) with [Package Control](http://packagecontrol.io). This way you can make use of the [myPDDL package](https://github.com/Pold87/myPDDL), which will give you syntax higlighting. 
+You can use your own text editor, the online editor at [planning.domains](http://editor.planning.domains), but I would recommend using [Visual Studio Code](https://code.visualstudio.com/#alt-downloads) with the [PDDL](https://marketplace.visualstudio.com/items?itemName=jan-dolejsi.pddl) extension, which will give you syntax higlighting, hover-over information, auto-completion, plan visualization and validation and more. It also automatically downloads the VAL binaries and.
 
 ## Components of PDDL
 


### PR DESCRIPTION
The Environment Setup now points to online editor.planning.domains and VSCode.